### PR TITLE
Refactor roto command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ roto and movo could also be combined to run Four Corners:
 ros2 run scripted_bot_driver scripted_mover movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d
 ```
 roto is used to turn in relation to the current heading: 
-*Unmodified target angles can be specified as just a number in radians with positive values requesting a CCW direction. If a 'd' or 'p' is appended, the angle will be interpreted as degrees, or to be multiplied by pi, respectively.
-*so -3.14159 and -1p and -180d are all treated as a half rotation in the clockwise direction in strict mode.
-*mode is either 1 or 2 if specified. Mode 1 is the default and seeks the shortest path. So if not specified, a roto 181d would actually result in a -179 degree rotation. The specified target angle will be normalized, so you'll never see more than a half rotation. Mode 2 is strict, meaning it requests a relative rotation from the starting heading exactly as specified. A "roto -4p 2" will execute 2 full rotations clockwise.
-*the remaining optional arguments require all preceding arguments to be supplied.
-*angular_speed, will override the default turning speed with the supplied speed in radians.
-*drive_speed, will add a forward or backward velocity, resulting in arcs. The value is in meters per second. Vary turning speed and drive speed for varying arcs. The terminating condition is always the final target rotation angle.
-*Accuracy is currently quite low and will always over-rotate. Reduce the angular_velocity to achieve better results. 
+- Unmodified target angles can be specified as just a number in radians with positive values requesting a CCW direction. If a 'd' or 'p' is appended, the angle will be interpreted as degrees, or to be multiplied by pi, respectively.
+- so -3.14159 and -1p and -180d are all treated as a half rotation in the clockwise direction in strict mode.
+- mode is either 1 or 2 if specified. Mode 1 is the default and seeks the shortest path. So if not specified, a roto 181d would actually result in a -179 degree rotation. The specified target angle will be normalized, so you'll never see more than a half rotation. Mode 2 is strict, meaning it requests a relative rotation from the starting heading exactly as specified. A "roto -4p 2" will execute 2 full rotations clockwise.
+- the remaining optional arguments require all preceding arguments to be supplied.
+- angular_speed, will override the default turning speed with the supplied speed in radians.
+- drive_speed, will add a forward or backward velocity, resulting in arcs. The value is in meters per second. Vary turning speed and drive speed for varying arcs. The terminating condition is always the final target rotation angle.
+- Accuracy is currently quite low and will always over-rotate. Reduce the angular_velocity to achieve better results. 
 
 A compatible simulation can be launched from the generic_turtlesim package, which
 is built around the ros2 turtlesim simulatork. It just reformats the simulator pose output

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ and a command to run the Four Corners DPRG contest could be:
 ros2 run scripted_bot_driver scripted_mover drive_waypoints 3 0 3 3 0 3 0 0
 ```
 Distance parameters are in meters and delay is in seconds.
-```
+
 
 roto and movo could also be combined to run Four Corners:
+```
 ros2 run scripted_bot_driver scripted_mover movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d
-
+```
 roto is used to turn in relation to the current heading: 
 *Unmodified target angles can be specified as just a number in radians with positive values requesting a CCW direction. If a 'd' or 'p' is appended, the angle will be interpreted as degrees, or to be multiplied by pi, respectively.
 *so -3.14159 and -1p and -180d are all treated as a half rotation in the clockwise direction in strict mode.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Run scripted_bot_driver without any commands to get the usage message:
 Usage: scripted_mover.py [commands] - executes the series of move commands provided
 Supported move commands are:
 movo <distance> [speed] - drive straight for <distance> meters
+roto <target_angle>[d|p] <mode> [angular_speed][d|p] [drive_speed]
 drive_waypoints <target_x> <target_y> [ more_targets ] - drive to a list of targets
 stop [delay]- ramp linear and rotational speed down to 0 with optional pause at end
 ```
@@ -40,6 +41,19 @@ and a command to run the Four Corners DPRG contest could be:
 ros2 run scripted_bot_driver scripted_mover drive_waypoints 3 0 3 3 0 3 0 0
 ```
 Distance parameters are in meters and delay is in seconds.
+```
+
+roto and movo could also be combined to run Four Corners:
+ros2 run scripted_bot_driver scripted_mover movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d movo 3 roto 90d
+
+roto is used to turn in relation to the current heading: 
+*Unmodified target angles can be specified as just a number in radians with positive values requesting a CCW direction. If a 'd' or 'p' is appended, the angle will be interpreted as degrees, or to be multiplied by pi, respectively.
+*so -3.14159 and -1p and -180d are all treated as a half rotation in the clockwise direction in strict mode.
+*mode is either 1 or 2 if specified. Mode 1 is the default and seeks the shortest path. So if not specified, a roto 181d would actually result in a -179 degree rotation. The specified target angle will be normalized, so you'll never see more than a half rotation. Mode 2 is strict, meaning it requests a relative rotation from the starting heading exactly as specified. A "roto -4p 2" will execute 2 full rotations clockwise.
+*the remaining optional arguments require all preceding arguments to be supplied.
+*angular_speed, will override the default turning speed with the supplied speed in radians.
+*drive_speed, will add a forward or backward velocity, resulting in arcs. The value is in meters per second. Vary turning speed and drive speed for varying arcs. The terminating condition is always the final target rotation angle.
+*Accuracy is currently quite low and will always over-rotate. Reduce the angular_velocity to achieve better results. 
 
 A compatible simulation can be launched from the generic_turtlesim package, which
 is built around the ros2 turtlesim simulatork. It just reformats the simulator pose output

--- a/launch/record_run_launch.py
+++ b/launch/record_run_launch.py
@@ -1,0 +1,89 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, RegisterEventHandler, OpaqueFunction
+from launch.event_handlers import OnProcessExit
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+import os
+import signal
+import time
+from datetime import datetime
+
+def generate_launch_description():
+    # Declare the launch argument
+    arguments = DeclareLaunchArgument(
+        'arguments', 
+        default_value='',
+        description='Arguments for the scripted_mover node'
+    )
+
+    # Use LaunchConfiguration to capture the arguments
+    arguments_value = LaunchConfiguration('arguments')
+
+    # Get the current date and time for the bag directory name
+    current_time = datetime.now().strftime('%Y_%m_%d-%H_%M_%S')
+    bag_directory_name = f'rosbag2_{current_time}'
+
+    # Get the output directory from an environment variable, with a default fallback to the user's home directory with a dynamic name
+    default_bag_directory = os.path.join('/home', os.getenv('USER'), 'bag_files', bag_directory_name)
+    output_directory = os.getenv('ROS2_BAG_OUTPUT_DIRECTORY', default_bag_directory)
+
+    # Start rosbag recording - to support mcap on Humble:
+    # sudo apt install ros-humble-rosbag2-storage-mcap 
+    start_rosbag_record = ExecuteProcess(
+        cmd=['ros2', 'bag', 'record', '-a', '-s', 'mcap', '-o', output_directory],
+        output='screen'
+    )
+
+    # Function to stop rosbag recording
+    def stop_rosbag_record(context):
+        pid = start_rosbag_record.process_details['pid']
+        time.sleep(5)  # Delay for 5 seconds before stopping the recording
+        os.kill(pid, signal.SIGINT)
+        return []
+
+    # Function to launch the scripted mover with parsed arguments
+    def launch_scripted_mover(context):
+        arguments_str = context.launch_configurations['arguments']
+        arguments_list = arguments_str.split()
+        # Create the node with arguments, extra arguments will be filtered out at execution time
+        scripted_mover_node = Node(
+            package='scripted_bot_driver',
+            executable='scripted_mover',
+            name='scripted_mover',
+            output='screen',
+            arguments=arguments_list
+        )
+
+        return [scripted_mover_node]
+
+    # Function to filter out ROS 2 specific arguments and launch the node
+    def execute_filtered_node(context):
+        arguments_str = context.launch_configurations['arguments']
+        arguments_list = arguments_str.split()
+        # Filter out ROS 2 specific arguments
+        filtered_arguments_list = [arg for arg in arguments_list if not arg.startswith('--ros-args')]
+
+        # Directly execute the node with filtered arguments
+        scripted_mover_node = ExecuteProcess(
+            cmd=['ros2', 'run', 'scripted_bot_driver', 'scripted_mover'] + filtered_arguments_list,
+            output='screen'
+        )
+
+        # Register event handler to stop rosbag recording after the node finishes
+        stop_rosbag_record_handler = RegisterEventHandler(
+            OnProcessExit(
+                target_action=scripted_mover_node,
+                on_exit=[OpaqueFunction(function=stop_rosbag_record)]
+            )
+        )
+
+        return [scripted_mover_node, stop_rosbag_record_handler]
+
+    # OpaqueFunction to launch the filtered execution
+    scripted_mover_launcher = OpaqueFunction(function=execute_filtered_node)
+
+    return LaunchDescription([
+        arguments,
+        start_rosbag_record,
+        scripted_mover_launcher,
+    ])

--- a/scripted_bot_driver/AngleHunter.py
+++ b/scripted_bot_driver/AngleHunter.py
@@ -1,0 +1,112 @@
+from math import pi, radians, degrees, fmod
+from scripted_bot_driver.anglr import  Angle
+
+"""
+AngleHunter is useful in finding the (nominally declining) error between an initial target
+angle and subsequent current angle readings. Create AngleHunter with the target angle or 
+heading in radians, and provide a current angle with the update() method to find the 
+current error.
+
+Optionally disable the default shortest_path calculation, allowing for tracking multiple 
+turns. 
+
+The update() function must be called frequently enough that it doesn't miss a 
+current_heading crossing of the 0-2pi boundary. current_heading is expected to be normalized.
+
+The return value indicates the magnitude of the error and the sign indicates the direction 
+to reduce the error. 
+"""
+__author__ = "karim  virani (pondersome)"
+__version__ = "1.0"
+__license__ = "MIT"
+
+TAU = 2*pi
+
+class AngleHunter:
+    def __init__(self, target_angle, initial_heading, shortest_path=True):
+        
+        self.shortest_path = shortest_path
+        self.initial_heading = Angle(initial_heading)
+
+        # don't think of target_angle as a heading, it can be > 2pi magnitude
+        self.target_angle = Angle(target_angle) #this is the relative angle requested until the first update()
+        if shortest_path:
+            self.target_angle += self.initial_heading #target relative to initial heading
+            self.target_angle = self.initial_heading.angle_to(self.target_angle.normalized())
+
+        self.last_heading = None # signifies first update
+        self.cumulative_angle = Angle(0) # this is also not a heading, but a running count of the angle turned since the first update
+        self.error = self.target_angle 
+        self.delta_heading = Angle(0)
+        self.update(initial_heading)
+
+    def update(self, current_heading):
+        self.current_heading = Angle(current_heading).normalized() # allows us to pass non-normalized angles for unit testing even though an odemetry reading should already be normalized
+        if self.last_heading is not None:
+            self.delta_heading = self.last_heading.angle_to(self.current_heading) # assumes update is called frequently so that a half rotation won't be missed
+            self.cumulative_angle += self.delta_heading
+
+        self.last_heading = self.current_heading
+        
+        self.error = self.target_angle - self.cumulative_angle
+        # the sign of the error should indicate the direction of turn that will close the error
+        return self.error
+    
+    def __str__(self):
+        return f"AngleHunter: {self.target_angle.radians:.6f} target radians, degrees={self.target_angle.degrees:.6f}, shortest_path={self.shortest_path}))"
+
+    def __repr__(self):   
+        repr = f"AngleHunter: shortest_path={self.shortest_path}\n{self.target_angle.radians:.6f} target radians, degrees={self.target_angle.degrees:.6f}\n" 
+        if self.last_heading is not None: #no updates yet so can't return any calcs
+            repr += f"{self.initial_heading.radians:.6f} inith  radians, degrees={self.initial_heading.degrees:.6f}\n" + \
+            f"{self.current_heading.radians:.6f} headn  radians, degrees={self.current_heading.degrees:.6f}\n" + \
+            f"{self.delta_heading.radians:.6f} delta  radians, degrees={self.delta_heading.degrees:.6f}\n" + \
+            f"{self.cumulative_angle.radians:.6f} cumul  radians, degrees={self.cumulative_angle.degrees:.6f}\n" + \
+            f"{self.error.radians:.6f} error  radians, degrees={self.error.degrees:.6f}\n"
+        return repr 
+
+    def get_target_radians(self):
+        return self.target_angle.radians
+
+    def get_target_degrees(self):
+        return self.target_angle.degrees
+
+    def get_cumul_radians(self):
+        return self.cumulative_angle.radians
+
+    def get_cumul_degrees(self):
+        return self.cumulative_angle.degrees
+
+def d(rad):
+    return degrees(rad)
+
+def r(deg):
+    return radians(deg)
+
+# Test the AngleHunter class
+def test_angle_hunter():
+    test_cases = [
+        #{'target_angle': 0, 'shortest_path': True, 'headings': [181, 135, 100, 90, 45, 1, 355], 'description':'simple 180 turn approaching and overshooting. errors should decline through 0'},
+        #{'target_angle': 0, 'shortest_path': True, 'headings': [180, 235, 270, 330, 345, 359, 365], 'description':'simple 180 turn approaching and overshooting. errors should decline through 0'},
+        #{'target_angle': -90, 'shortest_path': True, 'headings': [80, 70, 50, 20, 355, 350],'description':'Approaching -90 degrees with shortest path'},
+        #{'target_angle': -180, 'shortest_path': True, 'headings': [0, -90, -180, -270, -360],'description':'Approaching -180 degrees with shortest path'},
+        #ok{'target_angle': 540, 'shortest_path': False, 'headings': [0, -45, 90, 180, 270, 360, 450, 540],'description':'Completing 1.5 turns to 540 degrees'},        
+        #ok{'target_angle': -360, 'shortest_path': False, 'headings': [0, 45, -90, -180, -270, -360, -450],'description':'Completing -1 turn to -360 degrees'},
+        {'target_angle': -355, 'shortest_path': False, 'headings': [355, 340, 300, 220, 180, 90, 0],'description':'Completing -1 turn to -360 degrees'},
+        #{'target_angle': 90, 'shortest_path': True, 'headings': [0, 10, 20, 350, 340, 330], 'description':'Testing wrap-around from just below 2pi to just above 0'}
+    ]
+
+    for case in test_cases:
+        ah = AngleHunter(r(case['target_angle']), case['shortest_path'])
+        print(f"\nTesting: {case['description']}")
+        print(f"Target angle: {case['target_angle']} degrees ({r(case['target_angle']):.2f} radians), Shortest Path: {case['shortest_path']}")
+        for heading in case['headings']:
+            error = ah.update(r(heading))
+            #print(f"Current Heading: {heading} degrees ({r(heading):.2f} radians), Error: {d(error):.2f} degrees ({error:.2f} radians)")
+            print(repr(ah))
+
+        print(f"Last Cumulative Angle: {ah.get_cumul_radians():.2f} radians ({ah.get_cumul_degrees():.2f} degrees)")
+        print(f"Target Angle: {ah.get_target_radians():.2f} radians ({ah.get_target_degrees():.2f} degrees)")
+
+if __name__ == '__main__':
+    test_angle_hunter()

--- a/scripted_bot_driver/anglr.py
+++ b/scripted_bot_driver/anglr.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+"""Planar angle mathematics library for Python.
+This fork of anglr is from https://github.com/pondersome/anglr
+"""
+
+__author__ = "Anthony Zhang (Uberi)"
+__version__ = "1.1.0"
+__license__ = "BSD"
+
+import math, numbers
+
+TAU = math.pi * 2
+
+class Angle:
+    def __init__(self, value = 0, mode = "radians"):
+        """
+        Creates an `Angle` instance representing the angle `value` in the angular unit specified by `mode`.
+        
+        `mode` can be "radians", "degrees", "gradians", "hours", "arcminutes", "arcseconds", or "vector" (see `angle_instance.vector` for more info).
+        """
+        if isinstance(value, Angle): self.radians = value.radians
+        elif mode == "vector": self.vector = value
+        elif not isinstance(value, numbers.Real): raise ValueError("Value \"{}\" must be a real-number-like object".format(value))
+        elif mode == "radians": self.radians = value
+        elif mode == "degrees": self.degrees = value
+        elif mode == "gradians": self.gradians = value
+        elif mode == "hours": self.hours = value
+        elif mode == "arcminutes": self.arcminutes = value
+        elif mode == "arcseconds": self.arcseconds = value
+        else: raise ValueError("Angle mode \"{}\" must be one of \"radians\", \"degrees\", \"gradians\", \"hours\", \"arcminutes\", \"arcseconds\", or \"vector\"".format(mode))
+    
+    # various conversions between angles and numerical representations of angles
+    @property
+    def degrees(self):
+        """Returns the represented angle in degrees as a plain number."""
+        return math.degrees(self.radians)
+    @degrees.setter
+    def degrees(self, value):
+        """Sets the represented angle to the angle represented by `value` in degrees."""
+        self.radians = math.radians(value)
+    @property
+    def gradians(self):
+        """Returns the represented angle in gradians as a plain number."""
+        return self.radians * 400 / TAU
+    @gradians.setter
+    def gradians(self, value):
+        """Sets the represented angle to the angle represented by `value` in gradians."""
+        self.radians = value * TAU / 400
+    @property
+    def hours(self):
+        """Returns the represented angle in hours as a plain number."""
+        return self.radians * 24 / TAU
+    @hours.setter
+    def hours(self, value):
+        """Sets the represented angle to the angle represented by `value` in hours."""
+        self.radians = value * TAU / 24
+    @property
+    def arcminutes(self):
+        """Returns the represented angle in arcminutes as a plain number."""
+        return (self.radians * 360 / TAU) * 60
+    @arcminutes.setter
+    def arcminutes(self, value):
+        """Sets the represented angle to the angle represented by `value` in arcminutes."""
+        self.radians = (value / 60) * TAU / 360
+    @property
+    def arcseconds(self):
+        """Returns the represented angle in arcseconds as a plain number."""
+        return (self.radians * 360 / TAU) * 3600
+    @arcseconds.setter
+    def arcseconds(self, value):
+        """Sets the represented angle to the angle represented by `value` in arcseconds."""
+        self.radians = (value / 3600) * TAU / 360
+    @property
+    def vector(self):
+        """Returns a 2D unit vector `(X_VALUE, Y_VALUE)` that is at the represented angle counterclockwise from the positive X axis (standard position)."""
+        return math.cos(self.radians), math.sin(self.radians)
+    @vector.setter
+    def vector(self, value):
+        """Sets the represented angle to the angle that `value`, a vector `(X_VALUE, Y_VALUE)`, has counterclockwise from the positive X axis (standard position)."""
+        if len(value) != 2: raise ValueError("Invalid vector \"{}\"".format(value))
+        if value[0] == 0 == value[1]: raise ValueError("Zero vector (0, 0) has undefined angle".format(value))
+        self.radians = math.atan2(value[1], value[0])
+    @property
+    def x(self):
+        """Returns the X axis component of a 2D unit vector `(X_VALUE, Y_VALUE)` at the represented angle counterclockwise from the positive X axis (standard position)."""
+        return math.cos(self.radians)
+    @property
+    def y(self):
+        """Returns the Y axis component of a 2D unit vector `(X_VALUE, Y_VALUE)` at the represented angle counterclockwise from the positive X axis (standard position)."""
+        return math.sin(self.radians)
+    
+    # make it behave like a real number
+    def __add__(self, angle):
+        if not isinstance(angle, Angle): raise ValueError("Addend \"{}\" must be an angle".format(angle))
+        return Angle(self.radians + angle.radians)
+    def __sub__(self, angle):
+        if not isinstance(angle, Angle): raise ValueError("Subtrahend \"{}\" must be an angle".format(angle))
+        return Angle(self.radians - angle.radians)
+    def __mul__(self, value):
+        if not isinstance(value, numbers.Real): raise ValueError("Multiplicand \"{}\" must be numerical".format(value))
+        return Angle(self.radians * value)
+    def __truediv__(self, value):
+        if not isinstance(value, numbers.Real): raise ValueError("Divisor \"{}\" must be numerical".format(value))
+        return Angle(self.radians / value)
+    def __rmul__(self, value):
+        if not isinstance(value, numbers.Real): raise ValueError("Multiplicand \"{}\" must be numerical".format(value))
+        return Angle(value * self.radians)
+    def __neg__(self): return Angle(-self.radians)
+    def __pos__(self): return Angle(self.radians)
+    def __abs__(self): return Angle(abs(self.radians))
+    def __round__(self): return Angle(round(self.radians))
+    def __lt__(self, angle):
+        if isinstance(angle, Angle): return self.radians < angle.radians
+        return NotImplemented
+    def __le__(self, angle):
+        if isinstance(angle, Angle): return self.radians <= angle.radians
+        return NotImplemented
+    def __eq__(self, angle):
+        if isinstance(angle, Angle): return math.isclose(self.radians,angle.radians, abs_tol=1e-9)
+        return NotImplemented
+    
+    # type conversions
+    def __complex__(self): return complex(self.radians)
+    def __int__(self): return int(self.radians)
+    def __float__(self): return float(self.radians)
+    def __str__(self): return "{} rad".format(self.radians)
+    def __repr__(self): return "<Angle {} rad>".format(self.radians)
+    def __hash__(self): return hash(self.radians)
+    def dump(self):
+        """Returns a string representation of the `Angle` instance that contains the represented angle in various units and formats, useful for debugging purposes."""
+        return "<Angle: {} radians, {} degrees, {} gradians, {} hours, {} arcminutes, {} arcseconds, offset ({}, {})>".format(self.radians, self.degrees, self.gradians, self.hours, self.arcminutes, self.arcseconds, self.x, self.y)
+    
+    # unit circle functions
+    def normalized(self, lower=0, upper=None):
+        """Returns a new `Angle` instance that represents the angle normalized on the unit circle to be between `lower` (inclusive) and `upper` (exclusive, defaults to `lower + TAU`)."""
+        if upper is None: upper = lower + TAU
+        if lower > upper: lower, upper = upper, lower # swap bounds if lower bound is greater than upper bound
+        range_width = upper - lower
+        
+        # Normalize to the range [0, range_width)
+        normalized_angle = (self.radians - lower) % range_width
+        
+        # Adjust to the range [lower_bound, upper_bound)
+        if normalized_angle < 0:
+            normalized_angle += range_width
+
+        return Angle(normalized_angle + lower)
+    def angle_between_clockwise(self, angle):
+        """Returns a new `Angle` instance that represents the clockwise angle from this `Angle` instance to `angle` on the unit circle (this is always non-negative)."""
+        return Angle((Angle(angle).radians - self.radians) % TAU)
+    def angle_between(self, angle):
+        """Returns a new `Angle` instance that represents the smallest of the two possible angles between `Angle` instance to `angle` on the unit circle (this is always non-negative)."""
+        angle = Angle(angle)
+        return min(self.angle_between_clockwise(angle), angle.angle_between_clockwise(self))
+    def angle_within(self, lower, upper, strictly_within = False):
+        """Returns `True` if this `Angle` instance is within the angles `lower` and `upper` on the unit circle - inclusive if `strictly_within` is falsy, exclusive otherwise. Returns `False` otherwise."""
+        if lower > upper: lower, upper = upper, lower # swap bounds if upper bound is greater than lower bound
+        lower, upper = Angle(lower), Angle(upper)
+        
+        # transform all angles into a coordinate space where the lower angle is the positive X-axis to make comparison easier
+        value = (self.radians - lower.radians) % TAU
+        upper_bound = (upper.radians - lower.radians) % TAU
+        if strictly_within: return 0 < value < upper_bound
+        return 0 <= value <= upper_bound
+    def angle_to(self, angle):
+        """Returns a new `Angle` instance that represents the angle with the smallest magnitude that, when added to this `Angle` instance, results in `angle` on the unit circle."""
+        clockwise = self.angle_between_clockwise(angle)
+        counterclockwise = -angle.angle_between_clockwise(self)
+        return clockwise if clockwise <= abs(counterclockwise) else counterclockwise

--- a/scripted_bot_driver/move_parent.py
+++ b/scripted_bot_driver/move_parent.py
@@ -8,6 +8,7 @@ import time
 import threading
 
 import rclpy
+import math
 from rclpy.node import Node
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
 
@@ -20,8 +21,8 @@ loop_rate = 10       # loop rate
 speed_default = 0.35    # driving speed, fwd or back
 low_speed_default = 0.15
 vel_slew_rate = 0.5 / loop_rate  # m/s^2 per loop
-rot_speed_default = 0.25    # rotating speed, rad/s
-low_rot_speed_default = 0.25
+rot_speed_default = math.pi/4    # rotating speed, rad/s
+low_rot_speed_default = rot_speed_default/3
 rot_slew_rate = 0.5 / loop_rate  # rad/s^2
 
 class MoveParent(Node):

--- a/scripted_bot_driver/rotate_odom.py
+++ b/scripted_bot_driver/rotate_odom.py
@@ -84,8 +84,7 @@ class RotateOdom(MoveParent):
             self.odom.pose.pose.orientation.w,
         ]
         euler_angles = tf_transformations.euler_from_quaternion(q)
-        self.euler_heading = euler_angles[2]  # should be 0 - 2pi increasing CCW from East at 0
-        self.heading = self.fixup_heading_heading(euler_angles[2], self.angle_to_turn)  # normalize heading to [0, 2pi)
+        self.heading = self.normalize_heading(euler_angles[2])  # normalize heading to [0, 2pi)
 
         if self.run_once:
             self.heading_start = self.heading
@@ -128,7 +127,7 @@ class RotateOdom(MoveParent):
         # stop if we've gone past the goal
         if ((self.angle_goal >= 0 and self.angle_error <= 0) or
             (self.angle_goal < 0 and self.angle_error >= 0)):
-            self.rot_speed = 0  # exceeded goal, stop immediately
+            self.rot_speed = 0.0  # exceeded goal, stop immediately
             self.send_move_cmd(0.0, self.slew_rot(0.0))
             self.rot_stopping = True  # wait until we've stopped before exiting
 

--- a/scripted_bot_driver/rotate_odom.py
+++ b/scripted_bot_driver/rotate_odom.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import string
 import sys
 import time
 from math import radians, degrees, copysign, sqrt, pow, pi, fmod
@@ -8,15 +9,23 @@ import rclpy
 import tf_transformations
 
 from scripted_bot_driver.move_parent import MoveParent
+from scripted_bot_driver.anglr import  Angle
+from scripted_bot_driver.AngleHunter import AngleHunter
 from scripted_bot_interfaces.msg import RotateOdomDebug
 
 
-target_close_angle = 0.3    # slow down when this close
-angle_correction_sim = 0.970
+target_close_angle = 0.3    # slow down when this close in radians
+angle_correction_sim = 1.0  # can use this to hack the cutoff to mitigate over rotation? was 0.970
 
 class RotateOdom(MoveParent):
     def __init__(self):
         super().__init__('rotate')
+        #  set up loop timer
+        self.last_time = self.get_clock().now()
+        self.estimated_loop_rate = 0.0
+        self.alpha = 0.1  # Smoothing factor for exponential moving average
+        self.commandedAngular = 0.0
+        self.rot_stopping = False
         self.run_once = True
 
         # Publisher for debug data
@@ -24,54 +33,66 @@ class RotateOdom(MoveParent):
         self.debug_pub = self.create_publisher(RotateOdomDebug, 'rotate_odom_debug', 10)
         self.angle_error = 0.0
 
+        # Initialize timer to call run method at 30 Hz - no worky
+        #self.timer = self.create_timer(1.0 / 30.0, self.run)
+
     def parse_argv(self, argv):
-        if (len(argv) != 1 and len(argv) != 2):
+        
+        if len(argv) not in [1, 2, 3]:
             self.get_logger().fatal('Incorrect number of args given to RotateOdom: {}'.format(len(argv)))
             return -1
-
+        self.shortest_path = True
         try:
-            angle_input = argv[0]
-            if angle_input[0] == '+':
-                clockwise = False
-            elif angle_input[0] == '-':
-                clockwise = True
-            else:
-                clockwise = None
-            angle_deg = float(angle_input)  # pick off first arg from supplied list - angle to turn in deg
+            sp = argv[1]
+            if sp == '-1':
+                self.shortest_path = False
+                
+            self.angle_goal = self.parse_angle_rad(argv[0])  # pick off first arg from supplied list
+            self.get_logger().info(f'argv[0] {argv[0]}')
         except ValueError:
-            self.get_logger().fatal('Rotation angle {} must be a float'.format(argv[0]))
+            self.get_logger().fatal('Rotation angle {} must be convertible to a float'.format(argv[0]))
             return -1
 
-        if clockwise is not None:
-            self.angle_goal = radians(abs(angle_deg)) * angle_correction_sim
-            if clockwise:
-                self.angle_goal = -self.angle_goal
-        else:
-            angle = radians(angle_deg)
-            if abs(angle) > pi:
-                angle = fmod(angle, 2 * pi)
-                if angle > pi:
-                    angle -= 2 * pi
-                elif angle < -pi:
-                    angle += 2 * pi
-            self.angle_goal = angle * angle_correction_sim
-
-        # check whether a rot_speed argument was supplied
+        # check whether a rot_speed argument was supplied. if ending in 'd' convert from degrees
         if len(argv) > 1:
             try:
-                rot_speed_arg = float(argv[1])
-                self.rot_speed = rot_speed_arg
-                self.get_logger().info('Using supplied rot_speed {}'.format(self.rot_speed))
+                rot_speed_arg = self.parse_angle_rad(argv[2])
+                self.get_logger().info(f'argv[2] {argv[2]}')
+                self.full_rot_speed = rot_speed_arg
+                self.get_logger().info(f'full_rot_speed {self.full_rot_speed}')
+                self.get_logger().info('Using supplied rot_speed {} radians'.format(self.rot_speed))
                 return 2
             except ValueError:
                 return 1
-        return 1            # return number of args consumed
+        
+        return 1  # return number of args consumed
+    
+    def parse_angle_rad(self, angle_str):
+        """ convert an angle string to a float value in radians. angles ending in 'd' will be converted from degrees"""
+        angle_rad = 0 # default return value if an angle isn't provided
+        if angle_str:
+            if angle_str[-1] in ['d', 'D']: 
+                angle_rad = radians(float(angle_str[:-1]))
+            else: 
+                angle_rad = float (angle_str)
+
+        return angle_rad
 
     def print(self):
-        self.get_logger().info('rotate {} deg'.format(self.angle_goal * 180 / pi))
+        self.get_logger().info(f'rotate {self.angle_goal} rad, {degrees(self.angle_goal)} deg')
 
-    # run is called at the rate until it returns true
+    # run is called regularly until it returns true
     def run(self):
+        current_time = self.get_clock().now()
+        time_diff = (current_time - self.last_time).nanoseconds / 1e9  # Convert nanoseconds to seconds
+        self.last_time = current_time
+
+        if time_diff > 0:
+            instant_loop_rate = 1.0 / time_diff
+            self.estimated_loop_rate = self.alpha * instant_loop_rate + (1.0 - self.alpha) * self.estimated_loop_rate
+
+        rot_slew_rate = 0.5 / self.estimated_loop_rate  # Adjusted slew rate based on estimated loop rate
+
         if not self.is_odom_started():
             self.get_logger().error('ERROR: robot odometry has not started - exiting')
             return True
@@ -84,37 +105,30 @@ class RotateOdom(MoveParent):
             self.odom.pose.pose.orientation.w,
         ]
         euler_angles = tf_transformations.euler_from_quaternion(q)
-        self.heading = self.normalize_heading(euler_angles[2])  # normalize heading to [0, 2pi)
-
+        self.heading = Angle(euler_angles[2]).normalized().radians  # normalize heading to [0, 2pi), though it should be already
+        
         if self.run_once:
             self.heading_start = self.heading
-            self.heading_goal = self.normalize_heading(self.heading_start + self.angle_goal)
+            self.get_logger().info(f'self.heading_start {self.heading_start}')
+            #initialize an AngleHunter to track heading error
+            self.ah=AngleHunter(self.angle_goal*angle_correction_sim, self.heading_start, self.shortest_path)
+            self.angle_goal = self.ah.get_target_radians() 
+            self.heading_goal = self.ah.get_target_radians()
             self.rot_stopping = False
-            self.full_turns = 0
-
-            self.get_logger().info('start heading: {:.2f}, goal: {:.2f}'.format(self.heading_start, self.heading_goal))
+            
+            self.get_logger().info(f'start goal: {self.heading_goal:.2f}')
             self.run_once = False
             self.rot_speed = self.full_rot_speed
+            self.get_logger().info(f'self.rot_speed runonce {self.rot_speed}')
             self.angular_cmd = 0.0
 
-        # Track the number of full turns
-        if self.angle_goal >= 0:
-            if self.heading < self.heading_start:
-                self.full_turns += 1
-        else:
-            if self.heading > self.heading_start:
-                self.full_turns -= 1
-
-        # Calculate the current angle rotated
-        current_angle_rotated = (self.full_turns * 2 * pi) + (self.heading - self.heading_start)
-
-        # Calculate the angle error
-        self.angle_error = self.angle_goal - current_angle_rotated
-
+        #  update our turn error
+        self.angle_error=self.ah.update(self.heading).radians
+        
         if self.rot_stopping:
             if abs(self.odom.twist.twist.angular.z) < 0.01:  # wait till we've stopped
                 self.run_once = True
-                self.get_logger().info('rotated: {} deg to heading {:.2f}'.format((self.heading - self.heading_start) * (180 / pi), self.heading))
+                self.get_logger().info(f'rotated: {self.ah.get_cumul_degrees()} deg to heading {self.heading}')
                 return True
             else:
                 self.publish_debug()
@@ -145,7 +159,7 @@ class RotateOdom(MoveParent):
         return False
 
     def publish_debug(self):
-        self.debug_msg.angle_goal = self.angle_goal
+        self.debug_msg.angle_goal = self.angle_goal #todo seems redundant with heading_goal?
         self.debug_msg.heading = self.heading
         self.debug_msg.heading_start = self.heading_start
         self.debug_msg.heading_goal = self.heading_goal
@@ -157,18 +171,26 @@ class RotateOdom(MoveParent):
         self.debug_msg.commanded_angular = self.commandedAngular
         self.debug_pub.publish(self.debug_msg)
 
-    def normalize_heading(self, angle):  # normalize heading to [0, 2pi)
-        angle = fmod(angle, 2 * pi)
-        if angle < 0:
-            angle += 2 * pi
-        return angle
+    def slew_rot(self, to):
+        rot_slew_rate = 0.5 / self.estimated_loop_rate  # Dynamic slew rate
+        return self.slew(self.commandedAngular, to, rot_slew_rate)
+
+    def slew(self, current, to, slew_rate):
+        diff = to - current
+        if diff > slew_rate:
+            return current + slew_rate
+        if diff < -slew_rate:
+            return current - slew_rate
+        return to
 
     def start_action_server(self):
         self.create_action_server('rotate_odom')
 
     def get_feedback(self):
-        text_feedback = 'Degrees remaining:'
+        text_feedback = 'Degrees remaining:' 
+        text_feedback = f'{repr(self.ah)}\nloop rate: {self.estimated_loop_rate:.2f} Hz'
         progress_feedback = degrees(self.angle_error)  # Set progress_feedback to angle_error
+        
         return text_feedback, progress_feedback
 
     def finish_cb(self):

--- a/scripted_bot_driver/rotate_odom.py
+++ b/scripted_bot_driver/rotate_odom.py
@@ -2,7 +2,7 @@
 
 import sys
 import time
-from math import radians, copysign, sqrt, pow, pi, asin, atan2
+from math import radians, degrees, copysign, sqrt, pow, pi, fmod
 
 import rclpy
 import tf_transformations
@@ -22,23 +22,39 @@ class RotateOdom(MoveParent):
         # Publisher for debug data
         self.debug_msg = RotateOdomDebug()
         self.debug_pub = self.create_publisher(RotateOdomDebug, 'rotate_odom_debug', 10)
+        self.angle_error = 0.0
 
     def parse_argv(self, argv):
         if (len(argv) != 1 and len(argv) != 2):
-            self.get_logger().fatal('Incorrrect number of args given to RotateOdom: {}'.format(len(argv)))
+            self.get_logger().fatal('Incorrect number of args given to RotateOdom: {}'.format(len(argv)))
             return -1
 
         try:
-            angle_deg = float(argv[0])  # pick off first arg from supplied list - angle to turn in deg - +ve = CCW
+            angle_input = argv[0]
+            if angle_input[0] == '+':
+                clockwise = False
+            elif angle_input[0] == '-':
+                clockwise = True
+            else:
+                clockwise = None
+            angle_deg = float(angle_input)  # pick off first arg from supplied list - angle to turn in deg
         except ValueError:
             self.get_logger().fatal('Rotation angle {} must be a float'.format(argv[0]))
             return -1
 
-        if angle_deg > 180.0 or angle_deg < -180.0:
-            self.get_logger().fatal('Rotation angle ({} deg) must be between -180 and +180'.format(argv[0]))
-            return -1
-
-        self.angle_to_turn = angle_deg * (pi / 180) * angle_correction_sim  # angle to rotate through, -pi to +pi
+        if clockwise is not None:
+            self.angle_goal = radians(abs(angle_deg)) * angle_correction_sim
+            if clockwise:
+                self.angle_goal = -self.angle_goal
+        else:
+            angle = radians(angle_deg)
+            if abs(angle) > pi:
+                angle = fmod(angle, 2 * pi)
+                if angle > pi:
+                    angle -= 2 * pi
+                elif angle < -pi:
+                    angle += 2 * pi
+            self.angle_goal = angle * angle_correction_sim
 
         # check whether a rot_speed argument was supplied
         if len(argv) > 1:
@@ -52,7 +68,7 @@ class RotateOdom(MoveParent):
         return 1            # return number of args consumed
 
     def print(self):
-        self.get_logger().info('rotate {} deg'.format(self.angle_to_turn * 180 / pi))
+        self.get_logger().info('rotate {} deg'.format(self.angle_goal * 180 / pi))
 
     # run is called at the rate until it returns true
     def run(self):
@@ -69,23 +85,35 @@ class RotateOdom(MoveParent):
         ]
         euler_angles = tf_transformations.euler_from_quaternion(q)
         self.euler_heading = euler_angles[2]  # should be 0 - 2pi increasing CCW from East at 0
-        self.heading = self.fixup_heading(euler_angles[2], self.angle_to_turn)  # range: -pi to +pi
+        self.heading = self.fixup_heading_heading(euler_angles[2], self.angle_to_turn)  # normalize heading to [0, 2pi)
 
         if self.run_once:
             self.heading_start = self.heading
-            self.heading_goal = self.heading + self.angle_to_turn  # goal can range 0 - 2pi for CCW and 0 - -2pi for CW turns
-            self.will_cross_pi = int(self.heading_goal / pi)  # values -1, 0, 1. 0 means [will cross CW, won't cross, will cross CCW]
-            #self.heading_goal -= self.crossing_pi * 2 * pi  # constrain heading_goal to +/- pi
-            self.crossed_pi = False
+            self.heading_goal = self.normalize_heading(self.heading_start + self.angle_goal)
             self.rot_stopping = False
+            self.full_turns = 0
+
+            self.get_logger().info('start heading: {:.2f}, goal: {:.2f}'.format(self.heading_start, self.heading_goal))
+            self.run_once = False
             self.rot_speed = self.full_rot_speed
             self.angular_cmd = 0.0
 
-            self.get_logger().info('start heading: {:.2f}, goal: {:.2f}, crossing_pi: {}'.format(self.heading_start, self.heading_goal, self.will_cross_pi))
-            self.run_once = False
+        # Track the number of full turns
+        if self.angle_goal >= 0:
+            if self.heading < self.heading_start:
+                self.full_turns += 1
+        else:
+            if self.heading > self.heading_start:
+                self.full_turns -= 1
+
+        # Calculate the current angle rotated
+        current_angle_rotated = (self.full_turns * 2 * pi) + (self.heading - self.heading_start)
+
+        # Calculate the angle error
+        self.angle_error = self.angle_goal - current_angle_rotated
 
         if self.rot_stopping:
-            if abs(self.odom.twist.twist.angular.z) < 0.01:     # wait till we've stopped
+            if abs(self.odom.twist.twist.angular.z) < 0.01:  # wait till we've stopped
                 self.run_once = True
                 self.get_logger().info('rotated: {} deg to heading {:.2f}'.format((self.heading - self.heading_start) * (180 / pi), self.heading))
                 return True
@@ -94,34 +122,22 @@ class RotateOdom(MoveParent):
                 return False
 
         # slow the rotation speed if we're getting close
-        if self.will_cross_pi == 0:
-            if ((self.angle_to_turn >= 0 and self.heading > (self.heading_goal - target_close_angle)) or
-                (self.angle_to_turn < 0 and self.heading < (self.heading_goal + target_close_angle))):
-                self.rot_speed = self.low_rot_speed
+        if abs(self.angle_error) < target_close_angle:
+            self.rot_speed = self.low_rot_speed
 
         # stop if we've gone past the goal
-        if self.will_cross_pi == 0 and \
-            ((self.angle_to_turn >= 0 and self.heading >= self.heading_goal) or \
-            (self.angle_to_turn < 0 and self.heading < self.heading_goal)):
-
-            self.rot_speed = 0.0     # exceeded goal, stop immediately
+        if ((self.angle_goal >= 0 and self.angle_error <= 0) or
+            (self.angle_goal < 0 and self.angle_error >= 0)):
+            self.rot_speed = 0  # exceeded goal, stop immediately
             self.send_move_cmd(0.0, self.slew_rot(0.0))
-            self.rot_stopping = True        # wait until we've stopped before exiting
+            self.rot_stopping = True  # wait until we've stopped before exiting
 
             self.publish_debug()
             return False
 
-        # +ve angle means turn left. Adjust pi-crossing detection to avoid early exit without movement
-        if self.angle_to_turn >= 0:
-            self.angular_cmd = self.slew_rot(self.rot_speed)
-            if ((self.will_cross_pi != 0) and (self.heading < (self.heading_start - 0.1))):
-                self.will_cross_pi = 0                 # robot crossed pi, now let the end-of-rotate logic work
-        else:
-            self.angular_cmd = self.slew_rot(-self.rot_speed)
-            if ((self.will_cross_pi != 0) and (self.heading > (self.heading_start + 0.1))):
-                self.will_cross_pi = 0                 # robot crossed pi, now let the end-of-rotate logic work
+        # Adjust rotation direction based on the angle error
+        self.angular_cmd = self.slew_rot(copysign(self.rot_speed, self.angle_error))
 
-        # self.get_logger().info(self.heading)
         self.send_move_cmd(0.0, self.angular_cmd)
 
         # publish debug data
@@ -130,11 +146,11 @@ class RotateOdom(MoveParent):
         return False
 
     def publish_debug(self):
-        self.debug_msg.angle = self.angle_to_turn
+        self.debug_msg.angle_goal = self.angle_goal
         self.debug_msg.heading = self.heading
         self.debug_msg.heading_start = self.heading_start
         self.debug_msg.heading_goal = self.heading_goal
-        self.debug_msg.crossing_pi = self.will_cross_pi
+        self.debug_msg.angle_error = self.angle_error
         self.debug_msg.rot_stopping = self.rot_stopping
         self.debug_msg.rot_speed = self.rot_speed
         self.debug_msg.angular_cmd = self.angular_cmd
@@ -142,21 +158,22 @@ class RotateOdom(MoveParent):
         self.debug_msg.commanded_angular = self.commandedAngular
         self.debug_pub.publish(self.debug_msg)
 
-    def fixup_heading(self, heading, angle_to_turn):     # normalize heading to 0 - 2pi from East for CCW turns, 0 - -2pi for CW turns
-        if angle_to_turn >= 0:
-            return heading
-        return heading - (2 * pi)
+    def normalize_heading(self, angle):  # normalize heading to [0, 2pi)
+        angle = fmod(angle, 2 * pi)
+        if angle < 0:
+            angle += 2 * pi
+        return angle
 
     def start_action_server(self):
         self.create_action_server('rotate_odom')
 
     def get_feedback(self):
-        text_feedback = 'TODO: add feedback'
-        progress_feedback = 0.0
+        text_feedback = 'Degrees remaining:'
+        progress_feedback = degrees(self.angle_error)  # Set progress_feedback to angle_error
         return text_feedback, progress_feedback
 
     def finish_cb(self):
-        results = [self.angle_to_turn]
+        results = [self.angle_goal]
         return results
 
 def main():
@@ -169,4 +186,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/scripted_bot_driver/rotate_odom.py
+++ b/scripted_bot_driver/rotate_odom.py
@@ -88,13 +88,13 @@ class RotateOdom(MoveParent):
     
     
     def parse_angle_rad(self, angle_str):
-        """ convert an angle string to a float value in radians. angles ending in 'd' will be converted from degrees"""
+        """ convert an angle string to a float value in radians. angles ending in 'p' will be multipied by pi and those ending in 'd' will be converted from degrees"""
         angle_rad = 0 # default return value if an angle isn't provided
         if angle_str:
             if angle_str[-1] in ['d', 'D']: 
                 angle_rad = radians(float(angle_str[:-1]))
             elif angle_str[-1] in ['p', 'P']: 
-                angle_rad = float (angle_str) * pi
+                angle_rad = (float (angle_str[:-1])) * pi
             else:
                 angle_rad = float (angle_str)
 

--- a/scripted_bot_driver/scripted_mover.py
+++ b/scripted_bot_driver/scripted_mover.py
@@ -147,7 +147,7 @@ def usage():
     print('Supported move commands are:')
     print('movo <distance> [speed] - drive straight for <distance> meters')
     #print('arc <angle> <radius> <f | b>')
-    print('roto <angle> [speed] - rotate <angle> degrees, +ve is CCW. Speed, if given, sets direction.')
+    print('roto <angle>[d] <mode> [speed][d] - rotate <angle>[d] radians unless [d] which means degrees, +ve is CCW., mode=1 is shortest path, mode 2 is full angle. Angular speed, if given, is in radians unless mark [d]egrees.')
     print('drive_waypoints <target_x> <target_y> [ more_targets ] - drive to a list of targets')
     print('stop [delay]- ramp linear and rotational speed down to 0 with optional pause at end')
     sys.exit()

--- a/scripted_bot_driver/scripted_mover.py
+++ b/scripted_bot_driver/scripted_mover.py
@@ -147,7 +147,7 @@ def usage():
     print('Supported move commands are:')
     print('movo <distance> [speed] - drive straight for <distance> meters')
     #print('arc <angle> <radius> <f | b>')
-    print('roto <angle>[d] <mode> [speed][d] - rotate <angle>[d] radians unless [d] which means degrees, +ve is CCW., mode=1 is shortest path, mode 2 is full angle. Angular speed, if given, is in radians unless mark [d]egrees.')
+    print('roto <target_angle>[d|p] <mode> [angular_speed][d]  [drive_speed] - rotate <angle> radians, or pi*<target_angle> if [p] or degrees if [d], +angle is CCW., mode 1  (default) is shortest_path, mode 2 is strict. Angular speed, if given, allows same modifiers as target_angle.  Drive speed if given is in meters per second, defaults to zero.')
     print('drive_waypoints <target_x> <target_y> [ more_targets ] - drive to a list of targets')
     print('stop [delay]- ramp linear and rotational speed down to 0 with optional pause at end')
     sys.exit()

--- a/scripted_bot_driver/test_headings.ipynb
+++ b/scripted_bot_driver/test_headings.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### if anglr isn't in local environment, get a copy from https://github.com/pondersome/anglr because of bugs in the normalized() method available through pip. Otherwise:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install anglr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.5707963267948966 rad -6.457718232379019 rad\n",
+      "90.0 350.0\n",
+      "c: -9.99999999999999\n",
+      "99.99999999999999 -99.99999999999999 350.0 350.0\n",
+      "True\n",
+      "-10.0\n",
+      "-9.99999999999999 -10.0\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from  math import pi, degrees, radians, fmod\n",
+    "from scripted_bot_driver.anglr import  Angle\n",
+    "\n",
+    "a = Angle(radians(90))\n",
+    "b = Angle(radians(-370))\n",
+    "\n",
+    "print(a, b)\n",
+    "print(a.normalized().degrees,b.normalized().degrees)\n",
+    "c=Angle( fmod(b,2*pi)) #shows fmod() follows c-style modulus convention, preserving negatives in the dividend\n",
+    "print('c:', c.degrees)\n",
+    "d=c.angle_to(a) #angle_to is always positive and is the shortest distance of the 2 options - always involves normalization\n",
+    "e=c-a\n",
+    "f=c.normalized()\n",
+    "g=f.normalized() # should be same as above - normalizing a second time should have no changes\n",
+    "print (d.degrees, e.degrees, f.degrees, g.degrees)\n",
+    "print(e==-d)\n",
+    "h=Angle(-10, \"degrees\")\n",
+    "print(h.degrees)\n",
+    "print(c.degrees,h.degrees)\n",
+    "print(h==c) #added small tolerance to angle equality checking to handle variations in modulus truncation methods\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AngleHunter: shortest_path=False\n",
+      "-1.600000 target radians, degrees=-91.673247\n",
+      "6.084171 inith  radians, degrees=348.597303\n",
+      "6.084171 headn  radians, degrees=348.597303\n",
+      "0.000000 delta  radians, degrees=0.000000\n",
+      "0.000000 cumul  radians, degrees=0.000000\n",
+      "-1.600000 error  radians, degrees=-91.673247\n",
+      "\n",
+      "AngleHunter: shortest_path=False\n",
+      "-1.600000 target radians, degrees=-91.673247\n",
+      "6.084171 inith  radians, degrees=348.597303\n",
+      "1.000000 headn  radians, degrees=57.295780\n",
+      "1.199015 delta  radians, degrees=68.698476\n",
+      "1.199015 cumul  radians, degrees=68.698476\n",
+      "-2.799015 error  radians, degrees=-160.371724\n",
+      "\n",
+      "AngleHunter: shortest_path=False\n",
+      "-1.600000 target radians, degrees=-91.673247\n",
+      "6.084171 inith  radians, degrees=348.597303\n",
+      "3.141590 headn  radians, degrees=179.999848\n",
+      "2.141590 delta  radians, degrees=122.704068\n",
+      "3.340605 cumul  radians, degrees=191.402545\n",
+      "-4.940605 error  radians, degrees=-283.075792\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "inith=6.084170703087942\n",
+    "\n",
+    "from  math import pi, degrees, radians, fmod\n",
+    "from scripted_bot_driver.AngleHunter import  AngleHunter\n",
+    "\n",
+    "ah = AngleHunter(-1.6,inith, False)\n",
+    "print (repr(ah))\n",
+    "ah.update(1)\n",
+    "print (repr(ah))\n",
+    "ah.update(3.14159)\n",
+    "print (repr(ah))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AngleHunter: 1.570796 target radians, degrees=90.000000, shortest_path=False))\n",
+      "AngleHunter: shortest_path=False\n",
+      "1.570796 target radians, degrees=90.000000\n",
+      "-3.141593 inith  radians, degrees=-180.000000\n",
+      "1.000000 headn  radians, degrees=57.295780\n",
+      "-2.141593 delta  radians, degrees=-122.704220\n",
+      "-2.141593 cumul  radians, degrees=-122.704220\n",
+      "3.712389 error  radians, degrees=212.704220\n",
+      "\n",
+      "AngleHunter: shortest_path=False\n",
+      "1.570796 target radians, degrees=90.000000\n",
+      "-3.141593 inith  radians, degrees=-180.000000\n",
+      "3.141590 headn  radians, degrees=179.999848\n",
+      "2.141590 delta  radians, degrees=122.704068\n",
+      "-0.000003 cumul  radians, degrees=-0.000152\n",
+      "1.570799 error  radians, degrees=90.000152\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from  math import pi, degrees, radians, fmod\n",
+    "from scripted_bot_driver.AngleHunter import  AngleHunter\n",
+    "\n",
+    "ah = AngleHunter(a.radians, radians(-180.0), False)\n",
+    "print (ah)\n",
+    "ah.update(1)\n",
+    "print (repr(ah))\n",
+    "ah.update(3.14159)\n",
+    "print (repr(ah))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.683185307179587\n"
+     ]
+    }
+   ],
+   "source": [
+    "def normalize_heading(angle):  # normalize heading to [0, 2pi)\n",
+    "    angle = fmod(angle, 2 * pi)\n",
+    "    if angle < 0:\n",
+    "        angle += 2 * pi\n",
+    "    return angle\n",
+    "\n",
+    "print (normalize_heading(-1.6))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-1.57\n"
+     ]
+    }
+   ],
+   "source": [
+    "def parse_angle_rad(angle_str):\n",
+    "    \"\"\" convert an angle string to a float value in radians. angles ending in 'd' will be converted from degrees\"\"\"\n",
+    "    angle_rad = 0 # default return value if an angle isn't provided\n",
+    "    if angle_str:\n",
+    "        if angle_str[-1] in ['d', 'D']: \n",
+    "            angle_rad = radians(float(angle_str[:-1]))\n",
+    "        else: \n",
+    "            angle_rad = float (angle_str)\n",
+    "\n",
+    "    return angle_rad\n",
+    "\n",
+    "print (parse_angle_rad(\"-1.57\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.366370614359172\n",
+      "0.916814692820414\n",
+      "5.366370614359172\n",
+      "0.916814692820414\n"
+     ]
+    }
+   ],
+   "source": [
+    "def normalize_heading(angle):  # normalize heading to [0, 2pi)\n",
+    "    angle = fmod(angle, 2 * pi)\n",
+    "    if angle < 0:\n",
+    "        angle += 2 * pi\n",
+    "    return angle\n",
+    "\n",
+    "inith=-6.084170703087942\n",
+    "inith= -7.2\n",
+    "print(normalize_heading(inith))\n",
+    "print(normalize_heading(-inith))\n",
+    "print(inith % (2*pi))\n",
+    "print(-inith % (2*pi))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-181.0\n",
+      "178.99999999999997\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scripted_bot_driver.anglr  import  Angle\n",
+    "x=-181\n",
+    "theta =  Angle(x,'degrees')\n",
+    "print (theta.degrees)\n",
+    "l  =  (theta.normalized())\n",
+    "m = (theta.angle_to(Angle(0)))\n",
+    "n = Angle(0).angle_to(l)\n",
+    "print (n.degrees)\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
             'rotate_odom = scripted_bot_driver.rotate_odom:main',
             'move_parent = scripted_bot_driver.move_parent:main',
             'scripted_mover = scripted_bot_driver.scripted_mover:main',
+            'angle_hunter = scripted_bot_driver.AngleHunter:main',
+            'anglr = scripted_bot_driver.anglr:main',
         ],
     },
 )


### PR DESCRIPTION
I refactored the roto command in scripted_bot_driver. It now supports both shortest path and "strict" angles. The target angle is always relative to the starting heading and can be specified in radians, as a multiplier to pi, or in degrees.  Shortest path is always normalized and never results in turns more than a half rotations. Strict angles will turn in the direction according to the sign of the target angle and can be any size. This allows multi-turn scanning operations.

Angular turn rate can override the default rate and a drive speed can be added, resulting in arcs. Arcs can be full circles or multiple circles when multi-turn strict target angles are specified. The terminating condition is always on reaching the target angle.

I can't say I've tested it enough to be fully confident that it is bug free, but it's ready to have the tires kicked. 

I'm not happy with the accuracy, but that's a whole other story ...